### PR TITLE
Release changes to AAMD to support AAM v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+
+## Development
+
+Alces Access Manager Daemon is designed to be run within a Clusterware
+environment; a Vagrantfile to use during development is available at
+https://github.com/alces-software/alces-access-manager/dev/multiple-nodes-el7/login-el7/Vagrantfile.
+
+Setting up for development within daemon directory in Clusterware environment:
+
+- Install RVM: https://rvm.io/
+- `rvm install ruby-2.2.1`
+- `cd /media/host/alces-access-manager-daemon`
+- `gem install bundler`
+- `sudo yum install git pam-devel ruby-devel -y`
+- `bundle install`
+
+
+Running the daemon:
+
+- Kill any existing daemon in environment: `sudo systemctl stop clusterware-alces-access-manager-daemon.service`
+- Start development daemon: `cd /media/host/alces-access-manager-daemon && rvmsudo bin/alces-access-manager-daemon`
+
+To forward daemon port:
+
+  - `ssh -L 25269:10.0.2.15:25269 -p 2222 vagrant@localhost`

--- a/lib/alces/access-manager-daemon/control.rb
+++ b/lib/alces/access-manager-daemon/control.rb
@@ -31,6 +31,12 @@ module Alces
         ::Rpam.auth(user, pass)
       end
 
+      # ping exists here to just return true if the client was successfully
+      # able to reach us.
+      def ping(options) # Argument is required for remote call to work.
+        true
+      end
+
       PRIVATE_METHODS = [ :as,
                           :to_s,
                           :class,

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -7,7 +7,8 @@ module Alces
       def sessions_info(username)
         {
           sessions: sessions_for(username),
-          session_types: session_types
+          session_types: session_types,
+          can_launch_compute_sessions: qdesktop_available
         }
       end
 
@@ -106,6 +107,11 @@ module Alces
           end
         end
         metadata_hash
+      end
+
+      def qdesktop_available
+        run '/bin/bash -c "type qdesktop"'
+        return $?.exitstatus == 0
       end
 
     end

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -51,7 +51,13 @@ module Alces
         # TODO: Better way to do this?
         # Run command in new session using setsid, so VNC session does not exit
         # if daemon is stopped.
-        run("source /etc/profile.d/alces-clusterware.sh && setsid #{launch_session_command}")
+        launch_output = run("source /etc/profile.d/alces-clusterware.sh && setsid #{launch_session_command}")
+
+        if $?.exitstatus != 0
+          launch_output # Return output with reason for failure.
+        else
+          true # Success.
+        end
       end
 
       private

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -28,7 +28,6 @@ module Alces
       def launch_session(session_type, request_compute_node=false)
         # TODO:
         # - Check session_type is valid.
-        # - Doesn't work properly, sessions die when the daemon dies.
 
         # This hack is needed to set $HOME to the correct value for the current
         # user we are acting as; this is not done when we setuid to act as this

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -41,8 +41,10 @@ module Alces
         launch_session_command = "#{alces_command} session start #{session_type}"
 
         # Run command in new session using setsid, so VNC session does not exit
-        # if daemon is stopped.
-        run("setsid #{launch_session_command}")
+        # if daemon is stopped. Also start in background and redirect
+        # stdin/stdout to /dev/null so this method does not need to wait for
+        # the session to start to return.
+        run("setsid #{launch_session_command} < /dev/null &>/dev/null &")
       end
 
       private

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -6,6 +6,7 @@ module Alces
     class SessionsHandler < BlankSlate
 
       def sessions_info(username)
+        set_correct_user_home
         {
           sessions: sessions_for(username),
           session_types: session_types,
@@ -15,15 +16,9 @@ module Alces
       end
 
       def launch_session(session_type, request_compute_node=false)
-        # TODO:
-        # - Check session_type is valid.
+        set_correct_user_home
 
-        # This hack is needed to set $HOME to the correct value for the current
-        # user we are acting as; this is not done when we setuid to act as this
-        # user but is needed to create sessions as them.
-        # TODO: do this a nicer way?
-        user_home = run('whoami').strip
-        ::ENV['HOME'] = run("echo ~#{user_home}").strip
+        # TODO: Check session_type is valid.
 
         # Different command used to launch sessions on login node (node this
         # daemon is running on) vs requesting a session on any available
@@ -55,6 +50,16 @@ module Alces
       end
 
       private
+
+      def set_correct_user_home
+        # This hack is needed to set $HOME to the correct value for the current
+        # user we are acting as; this is not done when we setuid to act as this
+        # user but is needed to correctly run clusterware `alces` commands as
+        # them.
+        # TODO: do this a nicer way?
+        user_home = run('whoami').strip
+        ::ENV['HOME'] = run("echo ~#{user_home}").strip
+      end
 
       def sessions_for(username)
         user_sessions_path = ::File.expand_path "~#{username}/.cache/clusterware/sessions"

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -110,7 +110,7 @@ module Alces
       end
 
       def qdesktop_available
-        run '/bin/bash -c "type qdesktop"'
+        run '/bin/bash -c "type qdesktop >/dev/null 2>&1"'
         return $?.exitstatus == 0
       end
 

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -9,7 +9,8 @@ module Alces
         {
           sessions: sessions_for(username),
           session_types: session_types,
-          can_launch_compute_sessions: qdesktop_available
+          can_launch_compute_sessions: qdesktop_available,
+          has_vpn: vpn_handler_enabled
         }
       end
 
@@ -30,7 +31,6 @@ module Alces
         if request_compute_node
           launch_session_command = "qdesktop #{session_type}"
         else
-          alces_command = ::File.join(clusterware_root, '/bin/alces')
           launch_session_command = "#{alces_command} session start #{session_type}"
         end
 
@@ -91,6 +91,10 @@ module Alces
         ::ENV['cw_ROOT'] || '/opt/clusterware'
       end
 
+      def alces_command
+        ::File.join(clusterware_root, '/bin/alces')
+      end
+
       # Run a shell command with backtick operator; need to do this this way as
       # no methods from Kernel are defined within this class (I assume to
       # prevent security holes as methods are being executed remotely).
@@ -119,6 +123,12 @@ module Alces
       def qdesktop_available
         run '/bin/bash -c "type qdesktop >/dev/null 2>&1"'
         return $?.exitstatus == 0
+      end
+
+      def vpn_handler_enabled
+        vpn_handler_enabled_regex = /^\[\*\].*base.*\/.*cluster-vpn.*$/
+        available_handlers = run "#{alces_command} handler avail"
+        !!(available_handlers =~ vpn_handler_enabled_regex)
       end
 
     end

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -41,10 +41,8 @@ module Alces
         launch_session_command = "#{alces_command} session start #{session_type}"
 
         # Run command in new session using setsid, so VNC session does not exit
-        # if daemon is stopped. Also start in background and redirect
-        # stdin/stdout to /dev/null so this method does not need to wait for
-        # the session to start to return.
-        run("setsid #{launch_session_command} < /dev/null &>/dev/null &")
+        # if daemon is stopped.
+        run("setsid #{launch_session_command}")
       end
 
       private

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -39,7 +39,10 @@ module Alces
 
         alces_command = ::File.join(clusterware_root, '/bin/alces')
         launch_session_command = "#{alces_command} session start #{session_type}"
-        run(launch_session_command)
+
+        # Run command in new session using setsid, so VNC session does not exit
+        # if daemon is stopped.
+        run("setsid #{launch_session_command}")
       end
 
       private

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -4,25 +4,11 @@ module Alces
   module AccessManagerDaemon
     class SessionsHandler < BlankSlate
 
-      def sessions_for(username)
-        user_sessions_path = ::File.expand_path "~#{username}/.cache/clusterware/sessions"
-        metadata_filename ='metadata.vars.sh'
-        session_metadata_glob = ::File.join(user_sessions_path, '*', metadata_filename)
-        session_uuid_regex = /#{::File.join(user_sessions_path, '([^/]+)', metadata_filename)}/
-
-        sessions = []
-        if ::Dir.exist? user_sessions_path
-          session_metadata_files = ::Dir.glob(session_metadata_glob)
-          session_metadata_files.map do |file|
-            metadata_text = ::File.read file
-            session_uuid = file.match(session_uuid_regex)[1]
-            sessions << parse_session(metadata_text).tap do |session|
-              session['uuid'] = session_uuid
-            end
-          end
-        end
-
-        {sessions: sessions, session_types: session_types}
+      def sessions_info(username)
+        {
+          sessions: sessions_for(username),
+          session_types: session_types
+        }
       end
 
       def launch_session(session_type, request_compute_node=false)
@@ -61,6 +47,26 @@ module Alces
       end
 
       private
+
+      def sessions_for(username)
+        user_sessions_path = ::File.expand_path "~#{username}/.cache/clusterware/sessions"
+        metadata_filename ='metadata.vars.sh'
+        session_metadata_glob = ::File.join(user_sessions_path, '*', metadata_filename)
+        session_uuid_regex = /#{::File.join(user_sessions_path, '([^/]+)', metadata_filename)}/
+
+        sessions = []
+        if ::Dir.exist? user_sessions_path
+          session_metadata_files = ::Dir.glob(session_metadata_glob)
+          session_metadata_files.map do |file|
+            metadata_text = ::File.read file
+            session_uuid = file.match(session_uuid_regex)[1]
+            sessions << parse_session(metadata_text).tap do |session|
+              session['uuid'] = session_uuid
+            end
+          end
+        end
+        sessions
+      end
 
       # Find all the dirs in $cw_ROOT/etc/sessions with a `session.sh` script;
       # these are the available session types for this cluster.

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -25,18 +25,29 @@ module Alces
         {sessions: sessions, session_types: session_types}
       end
 
+      def launch_session(session_type)
+        user_home = ::Kernel.send(:`, 'whoami').strip
+        ::ENV['HOME'] = ::Kernel.send(:`, "echo ~#{user_home}").strip
+        alces_command = ::File.join(clusterware_root, '/bin/alces')
+        launch_session_command = "#{alces_command} session start #{session_type}"
+        ::Kernel.send(:`, launch_session_command)
+      end
+
       private
 
       # Find all the dirs in $cw_ROOT/etc/sessions with a `session.sh` script;
       # these are the available session types for this cluster.
       def session_types
-        clusterware_root = ::ENV['cw_ROOT'] || '/opt/clusterware'
         session_types_dir = ::File.join(clusterware_root, '/etc/sessions')
         session_creation_filename = 'session.sh'
         ::Dir.entries(session_types_dir).select do |dir|
           dir_path = ::File.join(session_types_dir, dir)
           ::Dir.exist?(dir_path) && ::Dir.entries(dir_path).include?(session_creation_filename)
         end
+      end
+
+      def clusterware_root
+        ::ENV['cw_ROOT'] || '/opt/clusterware'
       end
 
       def parse_session(metadata_text)

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -1,3 +1,4 @@
+
 require 'yaml'
 
 module Alces
@@ -45,6 +46,12 @@ module Alces
         else
           true # Success.
         end
+      end
+
+      def vpn_config
+        # Return the tarred, gzipped VPN config to the server where it can be
+        # offered for download.
+        run "cd #{clusterware_root}/etc/openvpn/client/clusterware/ && tar -zcf - *"
       end
 
       private

--- a/lib/alces/access-manager-daemon/sessions_handler.rb
+++ b/lib/alces/access-manager-daemon/sessions_handler.rb
@@ -22,10 +22,22 @@ module Alces
           end
         end
 
-        sessions
+        {sessions: sessions, session_types: session_types}
       end
 
       private
+
+      # Find all the dirs in $cw_ROOT/etc/sessions with a `session.sh` script;
+      # these are the available session types for this cluster.
+      def session_types
+        clusterware_root = ::ENV['cw_ROOT'] || '/opt/clusterware'
+        session_types_dir = ::File.join(clusterware_root, '/etc/sessions')
+        session_creation_filename = 'session.sh'
+        ::Dir.entries(session_types_dir).select do |dir|
+          dir_path = ::File.join(session_types_dir, dir)
+          ::Dir.exist?(dir_path) && ::Dir.entries(dir_path).include?(session_creation_filename)
+        end
+      end
 
       def parse_session(metadata_text)
         metadata_hash = {}


### PR DESCRIPTION
The latest Access Manager requires these changes to AAMD to be released.

As far as I can tell, this release increases support for Clusterware sessions, and adds a pre-authentication `ping` method that AAM uses to verify that the daemon is alive and reachable.
